### PR TITLE
Custom timeout, possibility to also use for non-https urls 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,15 @@ https.get('https://yoursite.tld/yourpath', function(err, res){
 	}
 });
 
-var reqOptions = {method:'post', host:'yoursite.tld', path: '/yourpath', [port: 443], [headers: {header1: 'value1', header2: 'value2'}], [body: {}]};
+var reqOptions = {
+  method: 'post', 
+  host: 'yoursite.tld', 
+  path: '/yourpath', 
+  port: 443, 
+  [headers: {header1: 'value1', header2: 'value2'}], 
+  body: {},
+  timeout: 10000 // 10 sec.
+};
 
 https.request(reqOptions, function(err, res){
 	if (err){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-pinnedhttps",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A Cordova plugin allowing you to make https requests, with (fingerprint-based) certificate pinning",
   "main": "index.js",
   "cordova": {

--- a/src/ios/PinnedHTTPS.m
+++ b/src/ios/PinnedHTTPS.m
@@ -269,8 +269,20 @@
         [self.commandDelegate sendPluginResult: rslt callbackId: command.callbackId];
         return;
     }
-    NSURL *reqUrl = [NSURL URLWithString: [NSString stringWithFormat:@"https://%@:%@%@", [options objectForKey:@"host"], [options objectForKey:@"port"], [options objectForKey:@"path"]]];
-    NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:reqUrl cachePolicy: NSURLRequestReloadIgnoringCacheData timeoutInterval: 20.0];
+    NSURL *reqUrl;
+    if ([[options objectForKey:@"port"] integerValue] == 80) {
+        reqUrl = [NSURL URLWithString: [NSString stringWithFormat:@"http://%@:%@%@", [options objectForKey:@"host"], [options objectForKey:@"port"], [options objectForKey:@"path"]]];
+    }
+    else {
+        reqUrl = [NSURL URLWithString: [NSString stringWithFormat:@"https://%@:%@%@", [options objectForKey:@"host"], [options objectForKey:@"port"], [options objectForKey:@"path"]]];
+    }
+    NSNumber *timeoutNumber = [options objectForKey:@"timeout"];
+    NSTimeInterval timeout = 20.0;
+    if (timeoutNumber != nil) {
+        timeout = [timeoutNumber doubleValue] / 1000;
+    }
+
+    NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:reqUrl cachePolicy: NSURLRequestReloadIgnoringCacheData timeoutInterval: timeout];
     req.HTTPMethod = [method uppercaseString];
 	[req setValue: @"close" forHTTPHeaderField: @"Connection"];
 	[req setValue: @"utf-8" forHTTPHeaderField: @"Accept-Charset"];


### PR DESCRIPTION
I've added an option for setting the timeout. Also when you specify port 80, it will use an `http://` url instead of `https://`